### PR TITLE
Fix RN v0.66 Hermes Crash

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -14,7 +14,7 @@ export class Ok<T> {
 
 export class Err<T> {
 	public constructor(public readonly error: Error) {
-		console.error(error);
+		console.info(error);
 	}
 
 	public isOk(): this is Ok<T> {


### PR DESCRIPTION
This PR:
 - Changed `console.error` to `console.info` in result.ts to prevent crash on RN v0.66 Hermes.